### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "ionic serve"

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
 # Alcometer project
 
 This is a simple alcometer project by Leon Deng for OAMK using Ionic 4.
+
+[![Run on Repl.it](https://repl.it/badge/github/deng-leon/alcometer)](https://repl.it/github/deng-leon/alcometer)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@dengleon/alcometer).